### PR TITLE
Added regex rules for ignoring messages

### DIFF
--- a/db/migrate/004_add_ignore_rule.rb
+++ b/db/migrate/004_add_ignore_rule.rb
@@ -1,0 +1,12 @@
+Sequel.migration do
+  up do
+    create_table :ignore_rules do
+      primary_key :id
+      String :rule, unique: true
+    end
+  end
+
+  down do
+    drop_table :ignore_rules
+  end
+end

--- a/models/message.rb
+++ b/models/message.rb
@@ -1,3 +1,9 @@
 class Message < Sequel::Model
-
+  def ignore?
+    @@rules ||= self.db[:ignore_rules]
+    @@rules.any? do |rule_hash|
+      rule = Regexp.new(rule_hash[:rule])
+      !rule.match(self.from).nil?
+    end
+  end
 end

--- a/models/user.rb
+++ b/models/user.rb
@@ -40,7 +40,7 @@ class User < Sequel::Model
       message_model.rfc822 = NKF.nkf("-mw",message.raw_source)
       message_model.sent_at = message.date
       message_model.created_at = Time.now
-      message_model.save if message_model.valid?
+      message_model.save if message_model.valid? && !message.ignore?
     end
     self.update(last_fetch: Time.now)
   end


### PR DESCRIPTION
Added a table for storing regex rules for ignoring emails. This is a straight ruby regex and right now relies on us manually inserting into the database the rules we want.

It stores the rules table in memory on first usage on the Message class so that we aren't hitting the database for it all of the time. This wont scale indefinitely into the future, but it will work for smallish numbers of users. We can probably push this off to a memory cache too (redis or memcached) to make it scale a bit better.

I also didn't create a model for these... not 100% sure if I like that so I'd appreciate opinions on that. It might be better to pull them in from a literal file, but then we have to add rules to the file during usage, so thats not great either.

**If we accept this PR we should also create an enhancement issue for a UI for rule creation**

Closes #3 
